### PR TITLE
Update Hype.fs

### DIFF
--- a/src/Hype/Hype.fs
+++ b/src/Hype/Hype.fs
@@ -283,7 +283,7 @@ and Util =
     /// Load values from delimited text file with given `filename` and separator characters `separators`
     static member LoadDelimited(filename:string, separators:char[]) =
         System.IO.File.ReadLines(filename)
-        |> Seq.map (fun x -> x.Split(separators) |> Array.map float32)
+        |> Seq.map (fun x -> x.Split(separators, StringSplitOptions.RemoveEmptyEntries) |> Array.map float32)
         |> Seq.map toDV
         |> DM.ofRows
     /// Load values from delimited text file with given `filename` and a default set of separator characters: space, comma, or tab


### PR DESCRIPTION
Example in http://hypelib.github.io/Hype/training.html 
let h = Util.LoadDelimited("housing.data") |> DM.Transpose

was not working with the file I downloaded from the original project because of spaces. Checking for null entries is good practice for safety.
