### PR TITLE
Fixing classification error for logistic classifier

### DIFF
--- a/src/Hype/Classifier.fs
+++ b/src/Hype/Classifier.fs
@@ -57,6 +57,9 @@ type LogisticClassifier(f) =
         cc
     override c.Classify(x:DV) =
         if c.Run(x).[0] > D 0.5f then 1 else 0
+    member c.ClassificationError(d:Dataset) =
+        let yi = d.Y |> DM.toDV |> DV.toArray |> Array.map (float32>>int)
+        c.ClassificationError(d.X, yi)
 
 /// Classifier for softmax classification
 type SoftmaxClassifier(f) =


### PR DESCRIPTION
The `Classification Error` function assumed one-hot encoding, which doesn't hold for logistic regression. Because of this, the classification error for logistic regression was not correct. 

This pull request adds a method that computes the correct classification error for binary data. 

I'm not sure if this is the best way to solve this. An alternative would be to have a special dataset constructor for binary data that would not assume one-hot encoding.
